### PR TITLE
[check]: check that we have enough items and return error otherwise

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,4 +7,5 @@ var (
 	errInvalidIndex              = errors.New("invalid index")
 	errInvalidKeyVector          = errors.New("invalid key vector")
 	errItemNotFoundOnGivenItemID = errors.New("item not found for give item id")
+	errNotEnoughItems            = errors.New("not enough items to build the tree")
 )

--- a/index.go
+++ b/index.go
@@ -60,6 +60,11 @@ func CreateNewIndex(rawItems [][]float64, dim, nTree, k int, m metric.Metric) (I
 			return nil, errDimensionMismatch
 		}
 	}
+
+	if len(rawItems) < 2 {
+		return nil, errNotEnoughItems
+	}
+
 	its := make([]*item, len(rawItems))
 	idToItem := make(map[itemId]*item, len(rawItems))
 	for i, v := range rawItems {

--- a/index_test.go
+++ b/index_test.go
@@ -66,3 +66,30 @@ func TestCreateNewIndex(t *testing.T) {
 	}
 
 }
+
+func TestCreateNewIndexNotEnoughItems(t *testing.T) {
+	rawItems := make([][]float64, 1)
+	rawItems[0] = []float64{1, 2, 3, 4}
+
+	m, err := metric.NewCosineMetric(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//1 vector is not enough
+	_, err = CreateNewIndex(rawItems, 4, 4, 2, m)
+	if err != errNotEnoughItems {
+		t.Fatalf("expected error errNotEnoughItems, got %v instead", err)
+	}
+
+	rawItems2 := make([][]float64, 2)
+	rawItems2[0] = []float64{1, 2, 3, 4}
+	rawItems2[1] = []float64{2, 2, 2, 2}
+
+	//2 vectors are ok
+	_, err = CreateNewIndex(rawItems2, 4, 4, 2, m)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+}


### PR DESCRIPTION
At the moment CreateNewIndex() panics if the number of vectors is less than 2. That happens because rand.Intn() call in GetSplittingVector() receives (lvs-1), which is <= 0.

I suggest to add a check and an error for that case, see the patch.
There is also a simple test for the error.